### PR TITLE
[FIX] Missing C99 check

### DIFF
--- a/backend/storage/tools/libs/tools/c99.rb
+++ b/backend/storage/tools/libs/tools/c99.rb
@@ -1,6 +1,6 @@
 class C99
   def self.check_domains
-    return if File.zero?('')
+    return unless File.exist?("#{OPTIONS[:output]}/whoxy_domains.txt")
 
     domains = File.open("#{OPTIONS[:output]}/whoxy_domains.txt").read
     domains.each_line do |domain|


### PR DESCRIPTION
Add missing C99 check.
When whoxy results is empty, the file is not created