### PR TITLE
[FEATURE] Update domain date if rescan

### DIFF
--- a/backend/app/controllers/scans_controller.rb
+++ b/backend/app/controllers/scans_controller.rb
@@ -233,9 +233,11 @@ class ScansController < ApplicationController
   end
 
   def launch_scan(cmd, scan, server, base_domain)
-    Domain.create(name: scan.domain) if scan.type_scan == 'recon' && Domain.find_by(name: scan.domain).nil?
-    Scope.find_by(scope: base_domain)&.update(last_scan: Time.now) unless scan.type_scan == 'nuclei'
+    if scan.type_scan == 'recon'
+      Domain.find_by(name: scan.domain).nil? ? Domain.create(name: scan.domain) : domain.update(updated_at: Time.now)
+    end
 
+    Scope.find_by(scope: base_domain)&.update(last_scan: Time.now) unless scan.type_scan == 'nuclei'
     Thread.start do
       # Sleep until the server starts and install the necessary tools
       sleep(360)


### PR DESCRIPTION
https://github.com/EasyRecon/Hunt3r/issues/185
If the domain does not exist at the time of the launch of a scan, it is added but if a scan is re-launched, the date was not updated, which could lead to confusion because the `updated_at` field is displayed in the UI.

Now when we restart a scan, the field will be updated with the new date